### PR TITLE
Get Travis synced back with this branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 jspm_packages
 .idea
 .DS_Store
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,10 @@ deploy:
     on:
       branch: develop
     wait-until-deployed: true
+
+notifications:
+    slack:
+        on_pull_requests: false
+        rooms:
+            - secure: "D8Gps3J/FPlBFWbiIHHX8i4hW3P8OLkdKwh2dby9AYGW3Ea3WfX6QgwA/OPzGQoYQH11ZmKbKLMHwS6/Jcmv1+uS3kmVWp/9Qh7nHTMpl35JJd88fGz2PQzG0U0QQ6VYNJgQvR3Hht+yrxiAdTr7E6StCONShO09SuDjA4NnbyQ5pviKyIEsMswgX0jlydXPKrWtV71eX5W7K920fTXLX+gDJ8fbqI+QpjRdq/TCpzesuB8dihrOpQowh7e8GKhxg2pHlDnCY89S3rlUHpInhbW5N6cGQai4/cWY48/6jZtGLj2LeX0LoYbsw5crbkH2X+CBxt0KsGjPTllkuCBx4NAIdWD7knFYlQhiDSOnv29j778Gm47MNkm6HJKSKf12umNRug+pwCoWVjVFsnMMByv4DD1/8+Sz4B37Xosx5zv+n0Nvo70FjnSxyREUrrAWBmAtAREuGswdxt5JnUEnzGZu9KHOmiCRn8oYlZnRoxrnYwo1xzNPdpPoz8Nb51V1GsZKMqGAPNeeglXfNDOmuyTLSxE5DUuIZt9bnT+SoTuYC4S+Jlnh8GMjL/uNQEyRo6wVwHg/WWulaURBLGNOZLL83qQztK1UtdQpHlCWqNAVYAo1seFntgAXNCoavxLW1SWZqmO3nQBEZHTGwGJzecHZImQ4f2/5uM+EVkn+wZ8=" # web-app channel
+            - secure: "djO5/t9pOlMgKSNx/EP01kusC9PZOEfvgFp7QohABSiikMJfCnXqGmsWV/8COEKoUUIWbWvw2lvQD9XojjcfuWiGSmO+NIvzilLUTp8NWl7t/1D8BfPkMYaSe2V/2hv83fpvd0zlGh19tgR2P3Vf6rwe/NuymG29LJkJSlINI3x4+lslvYGhDcJ1G6a7T14zcKdPjh5Ids0KYV6RBZARjnjviAEqVwd+S/tQVFzgYgEtCL0PVFqu7lVElnpaZ7vtDitdjE4Gp1CLIfqvkQrYskcnxrFqrTABgxbYNnuzzCtY7hwTHf1mvOo/oT6KStr9659dTHmcUuSr0Q4rAaV7/zxrUCFxULKgrFptH2dEj8NA17jL4isGz57JC/11tHiV+2nJOc7mGW+xVO3toeeF2bg84bzrPnD5ZnfQWD+3Kk/NDq0HXIGLvCrnA5rZtrFW5AYsMtVrT4bC6J5KnCIoxwQ2cZrz8+S7DDPRVNdO8xRqNL+3gBXGY6YIzjS6kA3AxE9ZrIw9iJ4A9bVl+3Ev2r42LIiJc2FHNsdBF9Emey2lfFbfLOQ5/jo+9n8285sGQf64cIKt0y/Jclsvhs9xL6eFp+Ivv+hCPFN6nlK2td/C2fvrvlywXk1ock7uBphD11Q1ziTosg1Va4wZZteAIaBuNueOt4NLCvAr4vVaJKc=" # dev-ops channel

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # America Scores PACER Web App
-[![Build Status](https://travis-ci.org/CS4500-AmericaSCORES/america-scores-web-app.svg?branch=master)](https://travis-ci.org/CS4500-AmericaSCORES/america-scores-web-app)
-[![Coverage Status](https://coveralls.io/repos/github/CS4500-AmericaSCORES/america-scores-web-app/badge.svg?branch=AS-157)](https://coveralls.io/github/CS4500-AmericaSCORES/america-scores-web-app)
+[![Build Status](https://travis-ci.org/AmericaSCORES-Boston/america-scores-web-app.svg?branch=master)](https://travis-ci.org/AmericaSCORES-Boston/america-scores-web-app)
+[![Coverage Status](https://coveralls.io/repos/github/AmericaSCORES-Boston/america-scores-web-app/badge.svg?branch=master)](https://coveralls.io/github/AmericaSCORES-Boston/america-scores-web-app?branch=master)
 
 This is the source code for the web app portion the America Scores Boston's PACER data collection system. This was developed by students in Norteastern's CS4500 Software Development class.  
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
-    "auth0-lock": "^10.7.2",
+    "auth0-lock": "10.11.0",
     "jquery": "^3.1.1",
     "react": "^15.3.2",
     "react-bootstrap": "^0.30.7",


### PR DESCRIPTION
- Merges encrypted Travis/Slack stuff back into the YML
- Temp hardcodes the auth0-lock version at 10.11, at least until https://github.com/auth0/lock/issues/892 is fixed
- Fixes badges so they reflect the current state of the master branch

[AS-260](https://cs4500-jira.ccs.neu.edu/browse/AS-260)